### PR TITLE
ck-4.0: fix BFS compilation with -Werror=strict-prototypes

### DIFF
--- a/kernel/sched/bfs.c
+++ b/kernel/sched/bfs.c
@@ -525,12 +525,12 @@ static inline void update_task_priodl(struct task_struct *p)
 }
 
 #if defined(CONFIG_SMP) && !defined(CONFIG_64BIT)
-static inline void grq_priodl_lock()
+static inline void grq_priodl_lock(void)
 {
 	raw_spin_lock(&grq.priodl_lock);
 }
 
-static inline void grq_priodl_unlock()
+static inline void grq_priodl_unlock(void)
 {
 	raw_spin_unlock(&grq.priodl_lock);
 }


### PR DESCRIPTION
static inline void grq_priodl_lock()
 does not take arguments, so should be declared as:
static inline void grq_priodl_lock(void)

With -Werror=strict-prototypes (default in Fedora I believe) it lead to fail build:
kernel/sched/bfs.c:522:20: error: function declaration isn't a prototype [-Werror=strict-prototypes]
 static inline void grq_priodl_lock()

Full log: https://kojipkgs.fedoraproject.org//work/tasks/258/9750258/build.log